### PR TITLE
Fix: Set SFTP initial directory to your home directory

### DIFF
--- a/server/sshs.go
+++ b/server/sshs.go
@@ -383,6 +383,7 @@ func (s *SSHServer) startSftp(channel ssh.Channel, userHome string, requestingUs
 
 	serverOptions := []sftp.ServerOption{
 		// sftp.WithDebug(os.Stderr), // 启用 SFTP 调试输出
+		sftp.WithServerWorkingDirectory(userHome), // 将初始工作目录设置为用户主目录
 	}
 
 	if s.ReadOnlySftp {


### PR DESCRIPTION
The previous SFTP implementation started in the SSHD process's current working directory. This change utilizes the `WithServerWorkingDirectory` option from the `github.com/pkg/sftp` library to set the initial directory for SFTP sessions to your home directory, providing a more standard and user-friendly experience.